### PR TITLE
2299 | Add I2C EEPROM and I3C CCC examples

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,410 @@
+# Copilot Instructions for BMC C# SDK
+
+## Prerequisites
+
+### BMC Bridge Installation
+The C# SDK requires the BinhoMissionControl Bridge (bmcbridge) utility to be installed and added to the PATH environment variable. The Bridge is maintained separately from the SDK for independent versioning and updates.
+
+#### Windows Setup
+1. Download BMC Bridge installer from [Binho Support](https://support.binho.io/getting-started/c++-sdk/installation):
+   - Windows 32-bit or 64-bit version
+2. Default installation path: `C:\Program Files (x86)\BinhoMissionControlBridge`
+3. Add to PATH:
+   - Open System Properties (`Win + R`, type `sysdm.cpl`)
+   - Advanced tab → Environment Variables
+   - Edit System Variables → PATH
+   - Add `C:\Program Files (x86)\BinhoMissionControlBridge`
+
+#### Linux/macOS Setup
+1. Download appropriate binary from [Binho Support](https://support.binho.io/getting-started/c++-sdk/installation):
+   - macOS ARM/Intel
+   - Linux
+2. Extract to preferred location
+3. Add to PATH in shell config:
+   ```bash
+   # Add to ~/.zshrc (macOS) or ~/.bashrc (Linux)
+   export PATH=/path/to/bmcbridge:$PATH
+   ```
+4. Apply changes: `source ~/.zshrc` or `source ~/.bashrc`
+
+Verify installation: `bmcbridge --version`
+
+## Project Architecture
+This SDK facilitates communication with Binho Nova and Supernova USB host adapters through the BMC Bridge process. Key components:
+
+### Core Components
+- [`BridgeClient`](BridgeClient.cs) - Manages Bridge process communication via stdin/stdout
+- Example implementations:
+  - [`ExampleI3cBasics`](ExampleI3cBasics.cs) - Core I3C operations
+  - [`ExampleI3cIbis`](ExampleI3cIbis.cs) - IBI (In-Band Interrupt) handling
+  - [`ExampleI3cCcc`](ExampleI3cCcc.cs) - Common Command Code operations
+
+## Bridge Communication Patterns
+
+### Command Structure
+All Bridge commands follow a consistent JSON structure with transaction IDs, command names, and parameters:
+```csharp
+var responses = await bridgeClient.SendCommand(
+    "i3c_ccc_getpid",
+    new Dictionary<string, object> {
+        { "address", "08" },
+        { "pushPullClockFrequencyInMHz", "5" },
+        { "openDrainClockFrequencyInKHz", "2500" }
+    }
+);
+```
+
+### Standard Command Sequence
+Always follow this initialization pattern:
+```csharp
+// 1. Open connection
+await bridgeClient.SendCommand("open", 
+    new Dictionary<string, object> { 
+        { "address", "SupernovaSimulatedPort" } 
+    });
+
+// 2. Initialize protocol bus
+await bridgeClient.SendCommand("i3c_init_bus", 
+    new Dictionary<string, object> { 
+        { "busVoltageInV", "3.3" } 
+    });
+
+// 3. Perform operations...
+```
+
+### Response Processing
+Responses contain transaction IDs and should be processed as JsonElement. Always extract the final response for results:
+```csharp
+var response = responses.Last(); // Get final response
+var data = (JsonElement)response.Data;
+var result = data.GetProperty("result");
+
+// For payload data (hex string arrays):
+var payload = result.GetProperty("payload")
+                   .EnumerateArray()
+                   .Select(x => Convert.ToByte(x.GetString(), 16))
+                   .ToArray();
+```
+
+### Promise Response Handling
+Some commands return multiple responses. Check `is_promise` field:
+```csharp
+foreach (var response in responses)
+{
+    if (response.IsPromise)
+    {
+        // More responses expected
+        continue;
+    }
+    // Final response - process data
+}
+```
+
+## Development Workflow
+
+### Build and Run
+```bash
+dotnet build
+dotnet run i3c_basics    # Run basic I3C example
+```
+
+### Requirements
+- .NET 8.0 SDK
+- BMC Bridge in system PATH
+
+## Project Conventions
+
+### Data Formats
+- **Device addresses**: Hex strings without "0x" prefix (e.g., "08", "4E", "50")
+- **Subaddresses/Registers**: Hex strings (e.g., "0000", "76", "4E")
+- **Data payload**: Hex strings for writeBuffer (e.g., "04", "0F00", "DEADBEEF")
+- **Clock frequencies**: 
+  - I3C Push-pull: MHz as string (e.g., "5")
+  - I3C Open-drain: KHz as string (e.g., "1250", "2500")
+  - I2C Clock: KHz as string (e.g., "100", "400")
+- **Bus voltage**: Voltage as string (e.g., "1.8", "3.3")
+
+### Common I2C Parameters
+Standard parameter sets for I2C commands:
+```csharp
+// Basic I2C read/write parameters
+var i2cParams = new Dictionary<string, object>
+{
+    { "address", "50" },                    // Target device address
+    { "subaddress", "0000" },              // Register address
+    { "clockFrequencyInKHz", "100" },      // Clock frequency (100/400 KHz typical)
+    { "busVoltageInV", "3.3" }             // Bus voltage
+};
+```
+
+### Common I3C Parameters
+Standard parameter sets for I3C commands:
+```csharp
+// Basic I3C read/write parameters
+var i3cParams = new Dictionary<string, object>
+{
+    { "address", "08" },                        // Target device address
+    { "subaddress", "0000" },                  // Register address
+    { "mode", "SDR" },                         // Transfer mode (SDR, HDR-DDR)
+    { "pushPullClockFrequencyInMHz", "5" },    // PP clock frequency
+    { "openDrainClockFrequencyInKHz", "1250" } // OD clock frequency
+};
+```
+
+### Client Lifecycle
+Always use `using` statement for proper resource cleanup:
+```csharp
+using var bridgeClient = new BridgeClient("BinhoSupernova");
+await bridgeClient.StartAsync();
+// Operations...
+// Dispose called automatically
+```
+
+### Event Handling
+Subscribe to notifications for IBI and async events:
+```csharp
+bridgeClient.OnNotificationReceived += (sender, notification) => {
+    if (notification.TransactionId == "0") {
+        Console.WriteLine($"IBI/Notification: {notification.Data}");
+    }
+};
+```
+
+### Error Handling
+Always check response status and handle errors appropriately:
+```csharp
+if (response.Status != "success") {
+    var data = (JsonElement)response.Data;
+    if (data.TryGetProperty("error", out JsonElement error)) {
+        var message = error.GetProperty("message").GetString();
+        throw new InvalidOperationException($"Bridge error: {message}");
+    }
+}
+```
+
+### Helper Methods
+Create extension methods for common operations:
+```csharp
+// I3C helper method
+public async Task<List<CommandResponse>> SendI3cWriteUsingSubaddress(
+    string address, string subaddress, string writeBuffer)
+{
+    return await SendCommand("i3c_write_using_subaddress",
+        new Dictionary<string, object>
+        {
+            { "address", address },
+            { "subaddress", subaddress },
+            { "mode", "SDR" },
+            { "pushPullClockFrequencyInMHz", "5" },
+            { "openDrainClockFrequencyInKHz", "1250" },
+            { "writeBuffer", writeBuffer }
+        });
+}
+
+// I2C helper methods
+public async Task<List<CommandResponse>> SendI2cWriteUsingSubaddress(
+    string address, string subaddress, string writeBuffer)
+{
+    return await SendCommand("i2c_write_using_subaddress",
+        new Dictionary<string, object>
+        {
+            { "address", address },
+            { "subaddress", subaddress },
+            { "writeBuffer", writeBuffer },
+            { "clockFrequencyInKHz", "100" }
+        });
+}
+
+public async Task<List<CommandResponse>> SendI2cReadUsingSubaddress(
+    string address, string subaddress, int bytesToRead)
+{
+    return await SendCommand("i2c_read_using_subaddress",
+        new Dictionary<string, object>
+        {
+            { "address", address },
+            { "subaddress", subaddress },
+            { "bytesToRead", bytesToRead.ToString() },
+            { "busVoltageInV", "3.3" }
+        });
+}
+```
+
+## Common Bridge Commands
+
+### Device Management
+```csharp
+// Open connection to device
+await bridgeClient.SendCommand("open", 
+    new Dictionary<string, object> { { "address", "SupernovaSimulatedPort" } });
+
+// Get device information
+await bridgeClient.SendCommand("get_usb_string", 
+    new Dictionary<string, object> { { "subCommand", "MANUFACTURER" } });
+await bridgeClient.SendCommand("get_usb_string", 
+    new Dictionary<string, object> { { "subCommand", "FW_VERSION" } });
+
+// Close connection
+await bridgeClient.SendCommand("close");
+```
+
+### I2C Operations
+```csharp
+// Set bus voltage for I2C/SPI/UART
+await bridgeClient.SendCommand("i2c_spi_uart_set_bus_voltage", 
+    new Dictionary<string, object> { { "busVoltageInV", "3.3" } });
+
+// Configure I2C parameters
+await bridgeClient.SendCommand("i2c_set_parameters", 
+    new Dictionary<string, object> { { "clockFrequencyInKHz", "100" } });
+
+// Write to I2C device register
+await bridgeClient.SendCommand("i2c_write_using_subaddress", new Dictionary<string, object>
+{
+    { "address", "50" },
+    { "subaddress", "0000" },
+    { "writeBuffer", "42" },
+    { "clockFrequencyInKHz", "100" }
+});
+
+// Read from I2C device register
+await bridgeClient.SendCommand("i2c_read_using_subaddress", new Dictionary<string, object>
+{
+    { "address", "50" },
+    { "subaddress", "0000" },
+    { "bytesToRead", "1" },
+    { "busVoltageInV", "3.3" }
+});
+
+// Direct I2C write (no subaddress)
+await bridgeClient.SendCommand("i2c_write", new Dictionary<string, object>
+{
+    { "address", "50" },
+    { "writeBuffer", "DEADBEEF" },
+    { "clockFrequencyInKHz", "100" }
+});
+
+// Direct I2C read (no subaddress)
+await bridgeClient.SendCommand("i2c_read", new Dictionary<string, object>
+{
+    { "address", "50" },
+    { "bytesToRead", "4" },
+    { "busVoltageInV", "3.3" }
+});
+```
+
+### I3C Operations
+```csharp
+// Initialize I3C bus
+await bridgeClient.SendCommand("i3c_init_bus", 
+    new Dictionary<string, object> { { "busVoltageInV", "3.3" } });
+
+// Write to device register
+await bridgeClient.SendCommand("i3c_write_using_subaddress", new Dictionary<string, object>
+{
+    { "address", "08" },
+    { "subaddress", "0000" },
+    { "mode", "SDR" },
+    { "pushPullClockFrequencyInMHz", "5" },
+    { "openDrainClockFrequencyInKHz", "1250" },
+    { "writeBuffer", "04" }
+});
+
+// Read from device register
+await bridgeClient.SendCommand("i3c_read_using_subaddress", new Dictionary<string, object>
+{
+    { "address", "08" },
+    { "subaddress", "0000" },
+    { "mode", "SDR" },
+    { "pushPullClockFrequencyInMHz", "5" },
+    { "openDrainClockFrequencyInKHz", "1250" },
+    { "bytesToRead", "1" }
+});
+
+// Get device PID (Provisioned ID)
+await bridgeClient.SendCommand("i3c_ccc_getpid", new Dictionary<string, object>
+{
+    { "address", "08" },
+    { "pushPullClockFrequencyInMHz", "5" },
+    { "openDrainClockFrequencyInKHz", "2500" }
+});
+```
+
+## Best Practices
+
+### Command Sequencing
+1. **Always open connection first** with `open` command
+2. **Initialize protocol bus** before operations (e.g., `i3c_init_bus`)
+3. **Process responses sequentially** - wait for completion before next command
+4. **Handle promise responses** - check `is_promise` field for multi-part responses
+5. **Clean up resources** - use `using` statements and proper disposal
+
+### Response Validation
+```csharp
+// Always validate response before processing
+var response = responses.Last();
+if (response.Status == "success")
+{
+    var data = (JsonElement)response.Data;
+    var result = data.GetProperty("result");
+    // Process result...
+}
+else
+{
+    // Handle error case
+    Console.WriteLine($"Command failed: {response.Status}");
+}
+```
+
+### Hex Data Handling
+```csharp
+// Convert hex string array to byte array
+var payload = result.GetProperty("payload")
+    .EnumerateArray()
+    .Select(x => Convert.ToByte(x.GetString(), 16))
+    .ToArray();
+
+// Format bytes as hex for display
+Console.WriteLine($"Data: [{string.Join(", ", payload.Select(b => $"0x{b:X2}"))}]");
+```
+
+### Configuration Batching
+```csharp
+// Batch multiple I3C register configurations
+var i3cConfigCommands = new[]
+{
+    ("76", "00"), ("4E", "20"), ("13", "05"),
+    ("16", "40"), ("5F", "61"), ("60", "0F00")
+};
+
+foreach (var (reg, value) in i3cConfigCommands)
+{
+    await bridgeClient.SendCommand("i3c_write_using_subaddress", new Dictionary<string, object>
+    {
+        { "address", "08" },
+        { "subaddress", reg },
+        { "mode", "SDR" },
+        { "pushPullClockFrequencyInMHz", "5" },
+        { "openDrainClockFrequencyInKHz", "1250" },
+        { "writeBuffer", value }
+    });
+}
+
+// Batch multiple I2C EEPROM writes
+var eepromData = new[]
+{
+    ("0020", "01"), ("0021", "02"), ("0022", "03"),
+    ("0023", "04"), ("0024", "FF"), ("0025", "AA")
+};
+
+foreach (var (address, value) in eepromData)
+{
+    await bridgeClient.SendCommand("i2c_write_using_subaddress", new Dictionary<string, object>
+    {
+        { "address", "50" },
+        { "subaddress", address },
+        { "writeBuffer", value },
+        { "clockFrequencyInKHz", "100" }
+    });
+    await Task.Delay(5); // EEPROM write cycle time
+}
+```

--- a/BridgeClient.cs
+++ b/BridgeClient.cs
@@ -50,7 +50,7 @@ public class BridgeClient : IDisposable
     {
         var processStartInfo = new ProcessStartInfo
         {
-            FileName = "bridge",
+            FileName = "bmcbridge",
             Arguments = commandAdaptor,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
@@ -75,7 +75,7 @@ public class BridgeClient : IDisposable
 
     public async Task<List<CommandResponse>> SendCommand(
         string command,
-        Dictionary<string, object> paramsDict = null
+        Dictionary<string, object>? paramsDict = null
     )
     {
         transactionId++;

--- a/Bridge_API_Reference.md
+++ b/Bridge_API_Reference.md
@@ -1,0 +1,702 @@
+# Binho Mission Control Bridge API Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Bridge Service Layer](#bridge-service-layer)
+- [Command Adaptors](#command-adaptors)
+- [Command and Response Structure](#command-and-response-structure)
+- [Device Management Commands](#device-management-commands)
+- [Protocol Specific Commands](#protocol-specific-commands)
+  - [I3C Commands](#i3c-commands)
+  - [I2C Commands](#i2c-commands)
+  - [I3C Common Command Codes (CCC)](#i3c-common-command-codes-ccc)
+- [Response Handling](#response-handling)
+- [Error Handling](#error-handling)
+- [Examples](#examples)
+
+## Overview
+
+The Binho Mission Control Bridge (BMC Bridge) is a service layer that provides a unified interface for communicating with Binho USB host adapters (Nova and Supernova). The Bridge accepts JSON-formatted commands via stdin and returns JSON-formatted responses via stdout, enabling easy integration with various programming languages and development environments.
+
+### Key Features
+- **Unified API**: Consistent interface across all supported host adapters
+- **JSON Communication**: Standard JSON request/response format
+- **Asynchronous Operations**: Support for promise-based command execution
+- **Transaction Management**: Built-in transaction ID tracking
+- **Protocol Support**: I3C, I2C, SPI, UART, GPIO, and more
+- **Device Management**: Connection, configuration, and status monitoring
+
+## Bridge Service Layer
+
+The Bridge service acts as an intermediary between your application and the physical USB host adapter. It handles:
+
+- Device discovery and connection management
+- Protocol initialization and configuration
+- Command queuing and execution
+- Response formatting and delivery
+- Error handling and status reporting
+
+### Starting the Bridge
+
+```bash
+bmcbridge <CommandAdaptor>
+```
+
+**Command Adaptors:**
+- `BinhoSupernova` - For Supernova devices
+- `BinhoNova` - For Nova devices
+- `SupernovaSimulatedPort` - For simulation/testing
+
+## Command Adaptors
+
+Command adaptors are device-specific modules that translate generic Bridge commands into device-specific operations. Each adaptor handles:
+
+- Device-specific communication protocols
+- Hardware abstraction
+- Feature mapping
+- Error translation
+
+### Available Adaptors
+
+| Adaptor | Device | Description |
+|---------|--------|-------------|
+| BinhoSupernova | Supernova | Full-featured USB host adapter |
+| BinhoNova | Nova | Compact USB host adapter |
+| SupernovaSimulatedPort | Simulation | Virtual device for testing |
+
+## Command and Response Structure
+
+### Command Format
+
+All commands sent to the Bridge follow this JSON structure:
+
+```json
+{
+  "transaction_id": "string",
+  "command": "string",
+  "params": {
+    "parameter1": "value1",
+    "parameter2": "value2"
+  }
+}
+```
+
+**Fields:**
+- `transaction_id`: Unique identifier for command tracking
+- `command`: Command name (e.g., "open", "i3c_init_bus")
+- `params`: Object containing command-specific parameters
+
+### Response Format
+
+```json
+{
+  "transaction_id": "string",
+  "status": "string",
+  "type": "string",
+  "is_promise": boolean,
+  "data": object
+}
+```
+
+**Fields:**
+- `transaction_id`: Matches the command transaction ID
+- `status`: Command execution status ("success", "error", etc.)
+- `type`: Response type ("response", "notification", etc.)
+- `is_promise`: `true` if more responses are expected
+- `data`: Response payload containing results or error information
+
+## Device Management Commands
+
+### Device Connection
+
+#### `open`
+Opens connection to a host adapter.
+
+**Parameters:**
+```json
+{
+  "address": "string"  // Optional: specific device address
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "1",
+  "command": "open",
+  "params": {
+    "address": "SupernovaSimulatedPort"
+  }
+}
+```
+
+#### `close`
+Closes connection to the current device.
+
+**Parameters:** None
+
+#### `exit`
+Terminates the Bridge service.
+
+**Parameters:** None
+
+### Device Information
+
+#### `get_usb_string`
+Retrieves USB device information strings.
+
+**Parameters:**
+```json
+{
+  "subCommand": "string"  // MANUFACTURER, PRODUCT_NAME, SERIAL_NUMBER, HW_VERSION, FW_VERSION
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "2",
+  "command": "get_usb_string",
+  "params": {
+    "subCommand": "MANUFACTURER"
+  }
+}
+```
+
+## Protocol Specific Commands
+
+### I3C Commands
+
+#### Bus Initialization
+
+##### `i3c_init_bus`
+Initializes the I3C bus with specified voltage.
+
+**Parameters:**
+```json
+{
+  "busVoltageInV": "string"  // Bus voltage (e.g., "1.8", "3.3")
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "3",
+  "command": "i3c_init_bus",
+  "params": {
+    "busVoltageInV": "3.3"
+  }
+}
+```
+
+#### Data Transfer
+
+##### `i3c_write_using_subaddress`
+Writes data to a device using subaddressing.
+
+**Parameters:**
+```json
+{
+  "address": "string",                        // Device address (hex)
+  "subaddress": "string",                     // Register/subaddress (hex)
+  "mode": "string",                           // Transfer mode ("SDR", "HDR-DDR")
+  "pushPullClockFrequencyInMHz": "string",    // Push-pull clock frequency
+  "openDrainClockFrequencyInKHz": "string",   // Open-drain clock frequency
+  "writeBuffer": "string"                     // Data to write (hex)
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "4",
+  "command": "i3c_write_using_subaddress",
+  "params": {
+    "address": "08",
+    "subaddress": "0000",
+    "mode": "SDR",
+    "pushPullClockFrequencyInMHz": "5",
+    "openDrainClockFrequencyInKHz": "1250",
+    "writeBuffer": "04"
+  }
+}
+```
+
+##### `i3c_read_using_subaddress`
+Reads data from a device using subaddressing.
+
+**Parameters:**
+```json
+{
+  "address": "string",                        // Device address (hex)
+  "subaddress": "string",                     // Register/subaddress (hex)
+  "mode": "string",                           // Transfer mode ("SDR", "HDR-DDR")
+  "pushPullClockFrequencyInMHz": "string",    // Push-pull clock frequency
+  "openDrainClockFrequencyInKHz": "string",   // Open-drain clock frequency
+  "bytesToRead": "string"                     // Number of bytes to read
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "5",
+  "command": "i3c_read_using_subaddress",
+  "params": {
+    "address": "08",
+    "subaddress": "0000",
+    "mode": "SDR",
+    "pushPullClockFrequencyInMHz": "5",
+    "openDrainClockFrequencyInKHz": "1250",
+    "bytesToRead": "1"
+  }
+}
+```
+
+### I2C Commands
+
+#### Bus Voltage Setup
+
+##### `i2c_spi_uart_set_bus_voltage`
+Sets the bus voltage for I2C/SPI/UART protocols.
+
+**Parameters:**
+```json
+{
+  "busVoltageInV": "string"  // Bus voltage as float (e.g., "1.8", "3.3")
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "1",
+  "command": "i2c_spi_uart_set_bus_voltage",
+  "params": {
+    "busVoltageInV": "3.3"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "transaction_id": "1",
+  "status": "success",
+  "type": "command_response",
+  "is_promise": false,
+  "data": {
+    "is_response_to": "i2c_spi_uart_set_bus_voltage",
+    "status": "success"
+  }
+}
+```
+
+##### `i2c_set_parameters`
+Configures I2C communication parameters.
+
+**Parameters:**
+```json
+{
+  "clockFrequencyInKHz": "string"  // Clock frequency in KHz (e.g., "100", "400")
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "2",
+  "command": "i2c_set_parameters",
+  "params": {
+    "clockFrequencyInKHz": "400"
+  }
+}
+```
+
+#### Data Transfer
+
+##### `i2c_read`
+Reads data from an I2C device.
+
+**Parameters:**
+```json
+{
+  "address": "string",        // Device address (2-digit hex, e.g., "50")
+  "bytesToRead": "string",    // Number of bytes to read
+  "busVoltageInV": "string"   // Bus voltage as float
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "3",
+  "command": "i2c_read",
+  "params": {
+    "address": "50",
+    "bytesToRead": "4",
+    "busVoltageInV": "3.3"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "transaction_id": "3",
+  "status": "success",
+  "type": "command_response",
+  "is_promise": false,
+  "data": {
+    "is_response_to": "i2c_read",
+    "status": "success",
+    "data": ["DE", "AD", "BE", "EF"]
+  }
+}
+```
+
+##### `i2c_write`
+Writes data to an I2C device.
+
+**Parameters:**
+```json
+{
+  "address": "string",               // Device address (2-digit hex, e.g., "50")
+  "writeBuffer": "string",           // Data to write (hex string, e.g., "DEADBEEF")
+  "clockFrequencyInKHz": "string"    // Clock frequency in KHz
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "4",
+  "command": "i2c_write",
+  "params": {
+    "address": "50",
+    "writeBuffer": "DEADBEEF",
+    "clockFrequencyInKHz": "400"
+  }
+}
+```
+
+##### `i2c_read_using_subaddress`
+Reads data from an I2C device using subaddressing (register addressing).
+
+**Parameters:**
+```json
+{
+  "address": "string",        // Device address (2-digit hex, e.g., "50")
+  "subaddress": "string",     // Register address (e.g., "0001")
+  "bytesToRead": "string",    // Number of bytes to read
+  "busVoltageInV": "string"   // Bus voltage as float
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "5",
+  "command": "i2c_read_using_subaddress",
+  "params": {
+    "address": "50",
+    "subaddress": "0001",
+    "bytesToRead": "4",
+    "busVoltageInV": "3.3"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "transaction_id": "5",
+  "status": "success",
+  "type": "command_response",
+  "is_promise": false,
+  "data": {
+    "is_response_to": "i2c_read_using_subaddress",
+    "status": "success",
+    "data": ["DE", "AD", "BE", "EF"]
+  }
+}
+```
+
+##### `i2c_write_using_subaddress`
+Writes data to an I2C device using subaddressing (register addressing).
+
+**Parameters:**
+```json
+{
+  "address": "string",               // Device address (2-digit hex, e.g., "50")
+  "subaddress": "string",            // Register address (e.g., "0001")
+  "writeBuffer": "string",           // Data to write (hex string, e.g., "DEADBEEF")
+  "clockFrequencyInKHz": "string"    // Clock frequency in KHz
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "6",
+  "command": "i2c_write_using_subaddress",
+  "params": {
+    "address": "50",
+    "subaddress": "0001",
+    "writeBuffer": "DEADBEEF",
+    "clockFrequencyInKHz": "400"
+  }
+}
+```
+
+### I3C Common Command Codes (CCC)
+
+Common Command Codes are standardized I3C commands for device management and configuration. For more information, see the [I3C Common Command Codes documentation](https://support.binho.io/user-guide/protocols-and-interfaces/i3c-common-command-codes).
+
+#### `i3c_ccc_getpid`
+Retrieves the Provisioned ID (PID) from an I3C device.
+
+**Parameters:**
+```json
+{
+  "address": "string",                        // Device address (hex)
+  "pushPullClockFrequencyInMHz": "string",    // Push-pull clock frequency
+  "openDrainClockFrequencyInKHz": "string"    // Open-drain clock frequency (optional)
+}
+```
+
+**Example:**
+```json
+{
+  "transaction_id": "6",
+  "command": "i3c_ccc_getpid",
+  "params": {
+    "address": "08",
+    "pushPullClockFrequencyInMHz": "5",
+    "openDrainClockFrequencyInKHz": "2500"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "transaction_id": "6",
+  "status": "success",
+  "type": "response",
+  "is_promise": false,
+  "data": {
+    "result": {
+      "payload": ["48", "01", "23", "45", "67", "89"]
+    }
+  }
+}
+```
+
+#### Other CCC Commands
+
+The Bridge supports additional CCC commands including:
+- `i3c_ccc_getbcr` - Get Bus Characteristics Register
+- `i3c_ccc_getdcr` - Get Device Characteristics Register
+- `i3c_ccc_getstatus` - Get Device Status
+- `i3c_ccc_setmrl` - Set Maximum Read Length
+- `i3c_ccc_getmrl` - Get Maximum Read Length
+- `i3c_ccc_setmwl` - Set Maximum Write Length
+- `i3c_ccc_getmwl` - Get Maximum Write Length
+
+For the complete list of supported CCCs, refer to the [supported CCCs documentation](https://support.binho.io/user-guide/protocols-and-interfaces/i3c-common-command-codes#supported-cccs).
+
+## Response Handling
+
+### Promise Responses
+
+Some commands may return multiple responses. The `is_promise` field indicates whether additional responses are expected:
+
+- `is_promise: true` - More responses will follow
+- `is_promise: false` - This is the final response
+
+### Notifications
+
+Notifications are special responses with `transaction_id: "0"` that indicate asynchronous events such as:
+- In-Band Interrupts (IBIs)
+- Device state changes
+- Error conditions
+
+## Error Handling
+
+### Error Response Format
+
+```json
+{
+  "transaction_id": "string",
+  "status": "error",
+  "type": "response",
+  "is_promise": false,
+  "data": {
+    "error": {
+      "code": "string",
+      "message": "string",
+      "details": object
+    }
+  }
+}
+```
+
+### Common Error Codes
+
+| Code | Description |
+|------|-------------|
+| `DEVICE_NOT_FOUND` | Host adapter not found or connected |
+| `INVALID_PARAMETER` | Invalid command parameter |
+| `COMMUNICATION_ERROR` | Communication failure with device |
+| `TIMEOUT` | Command execution timeout |
+| `PROTOCOL_ERROR` | Protocol-specific error |
+
+## Examples
+
+### C# Integration
+
+```csharp
+using var bridgeClient = new BridgeClient("BinhoSupernova");
+await bridgeClient.StartAsync();
+
+// Open connection
+await bridgeClient.SendCommand("open", 
+    new Dictionary<string, object> { 
+        { "address", "SupernovaSimulatedPort" } 
+    });
+
+// Initialize I3C bus
+await bridgeClient.SendCommand("i3c_init_bus", 
+    new Dictionary<string, object> { 
+        { "busVoltageInV", "3.3" } 
+    });
+
+// Read device PID
+var responses = await bridgeClient.SendCommand("i3c_ccc_getpid", 
+    new Dictionary<string, object> {
+        { "address", "08" },
+        { "pushPullClockFrequencyInMHz", "5" }
+    });
+
+// Process response
+var response = responses.Last();
+var data = (JsonElement)response.Data;
+var result = data.GetProperty("result");
+var payload = result.GetProperty("payload")
+    .EnumerateArray()
+    .Select(x => Convert.ToByte(x.GetString(), 16))
+    .ToArray();
+
+Console.WriteLine($"PID: {string.Join(":", payload.Select(b => $"{b:X2}"))}");
+```
+
+### Command Line Usage
+
+```bash
+# Start Bridge
+bmcbridge BinhoSupernova
+
+# Send commands via stdin
+echo '{"transaction_id":"1","command":"open","params":{"address":"SupernovaSimulatedPort"}}' | bmcbridge BinhoSupernova
+```
+
+### Python Integration
+
+```python
+import json
+import subprocess
+
+# Start bridge process
+bridge = subprocess.Popen(
+    ['bmcbridge', 'BinhoSupernova'],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    text=True
+)
+
+# Send command
+command = {
+    "transaction_id": "1",
+    "command": "open",
+    "params": {"address": "SupernovaSimulatedPort"}
+}
+
+bridge.stdin.write(json.dumps(command) + '\n')
+bridge.stdin.flush()
+
+# Read response
+response = json.loads(bridge.stdout.readline())
+print(f"Status: {response['status']}")
+```
+
+### Advanced Features
+
+#### Handling IBIs (In-Band Interrupts)
+
+```csharp
+bridgeClient.OnNotificationReceived += (sender, notification) => {
+    if (notification.TransactionId == "0") {
+        // Handle IBI notification
+        Console.WriteLine($"IBI received: {notification.Data}");
+    }
+};
+```
+
+#### Batch Operations
+
+```csharp
+// Configure device with multiple register writes
+var configCommands = new[]
+{
+    ("76", "00"), ("4E", "20"), ("13", "05"),
+    ("16", "40"), ("5F", "61"), ("60", "0F00")
+};
+
+foreach (var (reg, value) in configCommands)
+{
+    await bridgeClient.SendCommand("i3c_write_using_subaddress",
+        new Dictionary<string, object>
+        {
+            { "address", "08" },
+            { "subaddress", reg },
+            { "mode", "SDR" },
+            { "pushPullClockFrequencyInMHz", "5" },
+            { "openDrainClockFrequencyInKHz", "1250" },
+            { "writeBuffer", value }
+        });
+}
+```
+
+## Best Practices
+
+1. **Always check response status** before processing data
+2. **Handle promise responses** appropriately for multi-part operations
+3. **Use appropriate clock frequencies** for your I3C devices
+4. **Implement timeout handling** for long-running operations
+5. **Subscribe to notifications** for event-driven applications
+6. **Properly dispose of resources** using `using` statements in C#
+7. **Use hex string format** for addresses and data payload
+8. **Validate parameters** before sending commands
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Bridge not found**: Ensure `bmcbridge` is in your system PATH
+2. **Device connection failures**: Check device is properly connected and powered
+3. **Communication timeouts**: Verify clock frequencies are appropriate for your device
+4. **Invalid addresses**: Ensure addresses are in correct hex string format
+5. **Protocol errors**: Check device documentation for supported features
+
+### Debug Information
+
+Enable verbose logging by setting environment variables:
+```bash
+export BMC_DEBUG=1
+bmcbridge BinhoSupernova
+```
+
+This documentation provides a comprehensive reference for the Binho Mission Control Bridge API. For additional examples and advanced usage, refer to the SDK examples and device-specific documentation.

--- a/ExampleI2cEeprom.cs
+++ b/ExampleI2cEeprom.cs
@@ -1,0 +1,260 @@
+using System.Text.Json;
+
+/// <summary>
+/// Example demonstrating basic I2C EEPROM operations using the BMC Bridge.
+/// This example shows how to:
+/// - Initialize I2C bus and set parameters
+/// - Write individual bytes and pages to EEPROM
+/// - Read data from EEPROM using subaddressing
+/// - Perform batch operations for efficient EEPROM programming
+/// - Display hex data in readable format
+/// 
+/// Target Device: I2C EEPROM at address 0x50 (typical for 24LC series)
+/// Common EEPROM types: 24LC01, 24LC02, 24LC04, 24LC08, 24LC16, etc.
+/// </summary>
+class ExampleI2cEeprom
+{
+    private static void PrintResponses(List<CommandResponse> responses, string operationName = "")
+    {
+        if (!string.IsNullOrEmpty(operationName))
+        {
+            Console.WriteLine($"=== {operationName} ===");
+        }
+        
+        foreach (var response in responses)
+        {
+            Console.WriteLine($"Transaction ID: {response.TransactionId}");
+            Console.WriteLine($"Status: {response.Status}");
+            Console.WriteLine($"Type: {response.Type}");
+            Console.WriteLine($"Is Promise: {response.IsPromise}");
+            
+            if (response.Status == "success" && response.Data is JsonElement data)
+            {
+                // Check if this is a read response with data array
+                if (data.TryGetProperty("data", out JsonElement dataElement))
+                {
+                    if (dataElement.ValueKind == JsonValueKind.Array)
+                    {
+                        // Handle array response (typical for read operations)
+                        var hexData = dataElement.EnumerateArray()
+                            .Select(x => x.GetString())
+                            .ToArray();
+                        Console.WriteLine($"Data: [{string.Join(", ", hexData.Select(h => $"0x{h}"))}]");
+                        
+                        // Try to display as ASCII if printable
+                        try
+                        {
+                            var bytes = hexData.Select(h => Convert.ToByte(h, 16)).ToArray();
+                            var ascii = System.Text.Encoding.ASCII.GetString(bytes);
+                            // Check if all characters are printable ASCII (32-126) or common control chars
+                            if (ascii.All(c => (c >= 32 && c <= 126) || c == '\0' || c == '\n' || c == '\r' || c == '\t'))
+                            {
+                                Console.WriteLine($"ASCII: \"{ascii.Replace('\0', '.')}\"");
+                            }
+                        }
+                        catch
+                        {
+                            // Ignore ASCII conversion errors
+                        }
+                    }
+                    else if (dataElement.ValueKind == JsonValueKind.String)
+                    {
+                        // Handle string response (typical for device info)
+                        Console.WriteLine($"Data: \"{dataElement.GetString()}\"");
+                    }
+                    else
+                    {
+                        // Handle other data types
+                        Console.WriteLine($"Data: {dataElement}");
+                    }
+                }
+                else
+                {
+                    // Print the entire data object if no 'data' property
+                    Console.WriteLine($"Response Data: {data}");
+                }
+            }
+            Console.WriteLine("----------------------------------------");
+        }
+        Console.WriteLine();
+    }
+
+    private static async Task<List<CommandResponse>> WriteEepromByte(BridgeClient client, string address, string memoryAddress, string data)
+    {
+        return await client.SendCommand("i2c_write_using_subaddress", new Dictionary<string, object>
+        {
+            { "address", address },
+            { "subaddress", memoryAddress },
+            { "writeBuffer", data },
+            { "clockFrequencyInKHz", "100" }  // Standard I2C speed for EEPROM
+        });
+    }
+
+    private static async Task<List<CommandResponse>> ReadEepromBytes(BridgeClient client, string address, string memoryAddress, int bytesToRead)
+    {
+        return await client.SendCommand("i2c_read_using_subaddress", new Dictionary<string, object>
+        {
+            { "address", address },
+            { "subaddress", memoryAddress },
+            { "bytesToRead", bytesToRead.ToString() },
+            { "busVoltageInV", "3.3" }
+        });
+    }
+
+    public static async Task Run()
+    {
+        Console.WriteLine("=== BMC I2C EEPROM Example ===");
+        Console.WriteLine("Demonstrating basic I2C EEPROM operations at address 0x50");
+        Console.WriteLine("This example will write and read data from an I2C EEPROM\n");
+
+        using var bridgeClient = new BridgeClient("BinhoSupernova");
+        await bridgeClient.StartAsync();
+
+        const string eepromAddress = "50"; // 0x50 - typical I2C EEPROM address
+
+        try
+        {
+            // 1. Open connection to device
+            Console.WriteLine("1. Opening connection to device...");
+            PrintResponses(
+                await bridgeClient.SendCommand("open", 
+                    new Dictionary<string, object> { { "address", "SupernovaSimulatedPort" } }),
+                "Open Connection"
+            );
+
+            // 2. Set bus voltage for I2C operations
+            Console.WriteLine("2. Setting bus voltage to 3.3V...");
+            PrintResponses(
+                await bridgeClient.SendCommand("i2c_spi_uart_set_bus_voltage", 
+                    new Dictionary<string, object> { { "busVoltageInV", "3.3" } }),
+                "Set Bus Voltage"
+            );
+
+            // 3. Configure I2C parameters
+            Console.WriteLine("3. Configuring I2C parameters (100 KHz)...");
+            PrintResponses(
+                await bridgeClient.SendCommand("i2c_set_parameters", 
+                    new Dictionary<string, object> { { "clockFrequencyInKHz", "100" } }),
+                "Set I2C Parameters"
+            );
+
+            // 4. Get device information
+            Console.WriteLine("4. Getting device information...");
+            PrintResponses(
+                await bridgeClient.SendCommand("get_usb_string", 
+                    new Dictionary<string, object> { { "subCommand", "MANUFACTURER" } }),
+                "Device Manufacturer"
+            );
+
+            PrintResponses(
+                await bridgeClient.SendCommand("get_usb_string", 
+                    new Dictionary<string, object> { { "subCommand", "PRODUCT_NAME" } }),
+                "Product Name"
+            );
+
+            // 5. Write single byte to EEPROM
+            Console.WriteLine("5. Writing single byte (0x42) to address 0x0000...");
+            PrintResponses(
+                await WriteEepromByte(bridgeClient, eepromAddress, "0000", "42"),
+                "Write Single Byte"
+            );
+            
+            // Small delay for EEPROM write cycle
+            await Task.Delay(10);
+
+            // 6. Read single byte from EEPROM
+            Console.WriteLine("6. Reading single byte from address 0x0000...");
+            PrintResponses(
+                await ReadEepromBytes(bridgeClient, eepromAddress, "0000", 1),
+                "Read Single Byte"
+            );
+
+            // 7. Write a string to EEPROM (batch operation)
+            Console.WriteLine("7. Writing string \"Hello EEPROM!\" starting at address 0x0010...");
+            var message = "Hello EEPROM!";
+            var messageBytes = System.Text.Encoding.ASCII.GetBytes(message);
+            var hexMessage = string.Join("", messageBytes.Select(b => $"{b:X2}"));
+            
+            PrintResponses(
+                await WriteEepromByte(bridgeClient, eepromAddress, "0010", hexMessage),
+                "Write String"
+            );
+            
+            // Delay for EEPROM write cycle
+            await Task.Delay(50);
+
+            // 8. Read back the string
+            Console.WriteLine("8. Reading back the string...");
+            PrintResponses(
+                await ReadEepromBytes(bridgeClient, eepromAddress, "0010", message.Length),
+                "Read String"
+            );
+
+            // 9. Batch operations - write configuration data
+            Console.WriteLine("9. Performing batch configuration write...");
+            var configData = new[]
+            {
+                ("0020", "01"), // Config register 1
+                ("0021", "02"), // Config register 2  
+                ("0022", "03"), // Config register 3
+                ("0023", "04"), // Config register 4
+                ("0024", "FF"), // Status register
+                ("0025", "AA"), // Test pattern 1
+                ("0026", "55"), // Test pattern 2
+                ("0027", "00")  // Reserved
+            };
+
+            foreach (var (address, value) in configData)
+            {
+                Console.WriteLine($"  Writing 0x{value} to address 0x{address}");
+                await WriteEepromByte(bridgeClient, eepromAddress, address, value);
+                await Task.Delay(5); // Short delay between writes
+            }
+            Console.WriteLine("Batch write completed!\n");
+
+            // 10. Batch read - verify configuration data
+            Console.WriteLine("10. Performing batch configuration read...");
+            for (int i = 0; i < configData.Length; i++)
+            {
+                var address = configData[i].Item1;
+                Console.WriteLine($"  Reading from address 0x{address}:");
+                PrintResponses(
+                    await ReadEepromBytes(bridgeClient, eepromAddress, address, 1),
+                    $"Read Config {i + 1}"
+                );
+            }
+
+            // 11. Sequential read of entire configuration block
+            Console.WriteLine("11. Reading entire configuration block (8 bytes)...");
+            PrintResponses(
+                await ReadEepromBytes(bridgeClient, eepromAddress, "0020", 8),
+                "Read Configuration Block"
+            );
+
+            // 12. Write and read test pattern
+            Console.WriteLine("12. Writing test pattern...");
+            var testPattern = "DEADBEEFCAFEBABE"; // 8 bytes of test data
+            PrintResponses(
+                await WriteEepromByte(bridgeClient, eepromAddress, "0030", testPattern),
+                "Write Test Pattern"
+            );
+            
+            await Task.Delay(20);
+
+            Console.WriteLine("13. Reading back test pattern...");
+            PrintResponses(
+                await ReadEepromBytes(bridgeClient, eepromAddress, "0030", 8),
+                "Read Test Pattern"
+            );
+
+            Console.WriteLine("=== I2C EEPROM Example Complete ===");
+            Console.WriteLine("All operations completed successfully!");
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error during I2C operations: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/ExampleI3cCcc.cs
+++ b/ExampleI3cCcc.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class ExampleI3cCcc
+{
+    public static async Task Run()
+    {
+        using var bridgeClient = new BridgeClient("BinhoSupernova");
+        await bridgeClient.StartAsync();
+
+        // First, open the connection and initialize the I3C bus
+        await bridgeClient.SendCommand(
+            "open",
+            new Dictionary<string, object> { { "address", "SupernovaSimulatedPort" } }
+        );
+        
+        await bridgeClient.SendCommand(
+            "i3c_init_bus",
+            new Dictionary<string, object> { { "busVoltageInV", "3.3" } }
+        );
+
+        // Send the GETPID command
+        var responses = await bridgeClient.SendCommand(
+            "i3c_ccc_getpid",
+            new Dictionary<string, object>
+            {
+                { "address", "08" },
+                { "pushPullClockFrequencyInMHz", "5" },
+                { "openDrainClockFrequencyInKHz", "2500" }
+            }
+        );
+
+        Console.WriteLine($"Received {responses.Count} responses");
+
+        // The actual result is typically in the last response
+        var response = responses.Last();
+
+        // Extract payload as JsonElement
+        var data = (JsonElement)response.Data;
+        var result = data.GetProperty("result");
+        var payload = result.GetProperty("payload")
+                           .EnumerateArray()
+                           .Select(x => Convert.ToByte(x.GetString(), 16))
+                           .ToArray();
+
+        // PID as byte array
+        Console.WriteLine($"PID = [{string.Join(", ", payload.Select(b => $"0x{b:X2}"))}]");
+        Console.WriteLine($"PID bytes: [{string.Join(", ", payload)}]");
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-class Program
+partial class Program
 {
     static async Task Main(string[] args)
     {
@@ -10,6 +10,8 @@ class Program
         {
             ["i3c_basics"]  = ExampleI3cBasics.Run,
             ["i3c_ibis"]    = ExampleI3cIbis.Run,
+            ["i3c_ccc"]     = ExampleI3cCcc.Run,
+            ["i2c_eeprom"]  = ExampleI2cEeprom.Run,
             // Add new examples here, like so:
             // ["example_key"] = ExampleClass.RunMethod,
         };

--- a/README.md
+++ b/README.md
@@ -8,14 +8,26 @@ Welcome to the Binho Mission Control C# SDK (BMC C# SDK), a software tool design
 
 - **Unified Interface**: The SDK operates through the BMC Bridge, a REPL service that provides a consistent API for interacting with various host adapters. It accepts JSON-formatted command requests and returns JSON-formatted responses, ensuring a standardized communication protocol.
 - **Extensibility**: Designed with extensibility in mind, the SDK allows for easy integration and control of future host adapters.
-- **Examples Included**: Comes with practical examples (`i3c_basics` and `i3c_ibis`) to help you get started quickly.
+- **Multiple Examples**: Comes with comprehensive examples including basic I3C operations, IBI handling, and Common Command Code (CCC) operations to help you get started quickly.
+- **Asynchronous Operations**: Built with modern C# async/await patterns for efficient, non-blocking operations.
 
 ## Prerequisites
 
-- **BMC Bridge Installation**: The BMC Bridge must be installed separately and located in your system's PATH to run the examples provided with this SDK. This ensures that the SDK can communicate with the host adapters through the Bridge seamlessly.
-  - On **Windows**, the bridge executable can typically be found in `C:\Program Files (x86)\BinhoMissionControlBridge` if the installer was used.
-  - On **Mac and Linux**, the location will be where the bridge package was unzipped.
-- **.NET SDK**: Ensure that the .NET SDK is installed on your development machine to build and execute the examples.
+### BMC Bridge Installation
+The BMC Bridge must be installed separately and located in your system's PATH to run the examples provided with this SDK. This ensures that the SDK can communicate with the host adapters through the Bridge seamlessly.
+
+#### Installation Locations:
+- **Windows**: The bridge executable can typically be found in `C:\Program Files (x86)\BinhoMissionControlBridge` if the installer was used.
+- **macOS and Linux**: The location will be where the bridge package was unzipped.
+
+#### Verification:
+After installation, verify the bridge is accessible by running:
+```bash
+bmcbridge --version
+```
+
+### .NET Requirements
+- **.NET 8.0 SDK**: This project targets .NET 8.0. Ensure that the .NET 8.0 SDK is installed on your development machine to build and execute the examples.
 
 ## Installation
 
@@ -27,8 +39,8 @@ git clone https://github.com/binhollc/bmc_sdk_c_sharp.git
 
 Navigate to the cloned directory and build the project:
 
-```
-cd bmc_sdk_c_sharpo
+```bash
+cd bmc_sdk_c_sharp
 dotnet build
 ```
 
@@ -36,26 +48,144 @@ dotnet build
 
 To run the provided examples, use the following command:
 
-```
+```bash
 dotnet run [example]
 ```
 
-Replace `[example]` with the name of the example you wish to execute (`i3c_basics` or `i3c_ibis`).
+Replace `[example]` with the name of the example you wish to execute. Available examples:
+- `i3c_basics` - Basic I3C operations
+- `i3c_ibis` - In-Band Interrupt (IBI) handling  
+- `i3c_ccc` - Common Command Code operations
+
+If no example is specified, the program will list all available examples.
 
 ## Examples
 
-- **i3c_basics**: Demonstrates basic I3C commands using the Supernova simulated host adapter.
-- **i3c_ibis**: Shows how to configure an IMU (ICM42605) to fire IBIs (In-Band Interrupts) and catch these notifications.
+### Available Examples
+
+- **`i3c_basics`**: Demonstrates fundamental I3C commands using the Supernova simulated host adapter. Shows basic bus initialization, device communication, and USB string retrieval.
+
+- **`i3c_ibis`**: Advanced example showing how to configure an IMU (ICM42605) to generate IBIs (In-Band Interrupts) and how to handle these notifications. Includes extended functionality through the `ExtendedBridgeClient` class.
+
+- **`i3c_ccc`**: Demonstrates Common Command Code (CCC) operations, specifically the GETPID command to retrieve device Provisioned IDs. Shows how to process structured responses and extract payload data.
+
+### Example Output Processing
+
+The SDK uses structured JSON responses that can be processed as follows:
+
+```csharp
+// Extract data from command responses
+var data = (JsonElement)response.Data;
+var result = data.GetProperty("result");
+var payload = result.GetProperty("payload")
+                   .EnumerateArray()
+                   .Select(x => Convert.ToByte(x.GetString(), 16))
+                   .ToArray();
+```
 
 ## Repository Contents
 
-- `BridgeClient.cs`: A service for interacting with the BMC Bridge via stdin/stdout.
-- `ExampleI3cBasics.cs`: A basic example showcasing I3C commands.
-- `ExampleI3cIbis.cs`: An advanced example demonstrating the catching of IBIs.
+### Core Components
 
-## Bridge's API
+- **`BridgeClient.cs`**: The main service class for interacting with the BMC Bridge via stdin/stdout. Handles asynchronous command execution, response processing, and event notifications. Includes transaction management and proper resource disposal.
 
-For detailed information about the Bridge's API, visit [Binho Support](https://support.binho.io/bridge-supernova-api-1.0).
+- **`Program.cs`**: Entry point that manages example selection and execution. Provides a clean interface for running different demonstration scenarios.
+
+### Example Implementations
+
+- **`ExampleI3cBasics.cs`**: Fundamental I3C operations including bus initialization, device communication, and basic command execution.
+
+- **`ExampleI3cIbis.cs`**: Advanced IBI (In-Band Interrupt) handling with IMU configuration. Features an extended bridge client with specialized I3C write operations.
+
+- **`ExampleI3cCcc.cs`**: Common Command Code operations demonstrating structured data extraction and device identification commands.
+
+### Project Configuration
+
+- **`bmc_sdk_c_sharp.csproj`**: .NET 8.0 project file with necessary dependencies and build configuration.
+
+## Architecture
+
+### Communication Flow
+
+1. **Bridge Process**: The SDK launches and manages the BMC Bridge process
+2. **JSON Commands**: Commands are sent as structured JSON via stdin
+3. **Async Responses**: Responses are processed asynchronously with transaction tracking
+4. **Event Handling**: Support for both command responses and asynchronous notifications
+
+### Key Features
+
+- **Transaction Management**: Each command gets a unique transaction ID for response correlation
+- **Resource Management**: Proper disposal patterns with `using` statements
+- **Event-Driven**: Support for response and notification event handlers
+- **Type Safety**: Strongly-typed response objects with JSON serialization
+
+## API Reference
+
+### Bridge's API Documentation
+
+For detailed information about the Bridge's API, visit [Binho Support](https://support.binho.io/user-guide/protocols-and-interfaces/bridge-1.1-api).
+
+### Basic Usage Pattern
+
+```csharp
+using var bridgeClient = new BridgeClient("BinhoSupernova");
+await bridgeClient.StartAsync();
+
+var responses = await bridgeClient.SendCommand(
+    "command_name",
+    new Dictionary<string, object> {
+        { "parameter1", "value1" },
+        { "parameter2", "value2" }
+    }
+);
+```
+
+### Command Response Structure
+
+```csharp
+public class CommandResponse
+{
+    public string TransactionId { get; set; }
+    public string Status { get; set; }
+    public string Type { get; set; }
+    public bool IsPromise { get; set; }
+    public JsonElement Data { get; set; }
+}
+```
+
+## Development and Troubleshooting
+
+### Common Issues
+
+1. **Bridge Not Found**: Ensure `bmcbridge` is in your system PATH and verify with `bmcbridge --version`
+2. **Permission Issues**: On Linux/macOS, you may need appropriate permissions for USB device access
+3. **Build Errors**: Ensure .NET 8.0 SDK is installed and project dependencies are restored
+
+### Adding New Examples
+
+To add a new example:
+
+1. Create a new class file (e.g., `ExampleNewFeature.cs`)
+2. Implement a static `Run()` method that returns `Task`
+3. Add your example to the dictionary in `Program.cs`:
+
+```csharp
+["example_key"] = ExampleNewFeature.Run,
+```
+
+### Event Handling
+
+The `BridgeClient` supports event handlers for responses and notifications:
+
+```csharp
+bridgeClient.OnResponseReceived += (sender, response) => {
+    Console.WriteLine($"Response: {response.Status}");
+};
+
+bridgeClient.OnNotificationReceived += (sender, notification) => {
+    Console.WriteLine($"Notification: {notification.Data}");
+};
+```
 
 ## Contributing
 


### PR DESCRIPTION
## Resolves

- https://focusuy.atlassian.net/browse/BMC2-2299

## Changes

- Added `ExampleI2cEeprom.cs` demonstrating comprehensive I2C operations:
  - Bus voltage setup, parameter configuration, and device information retrieval
  - Single-byte and string writing/reading operations
  - Batch operations for configuration data
  - Hex data display with ASCII conversion for readability
  - Proper EEPROM write cycle delays

- Added `ExampleI3cCcc.cs` demonstrating I3C Common Command Code (CCC) operations:
  - GETPID command execution and payload extraction
  - Proper response processing for structured I3C data

- Updated `Program.cs` to include new examples (`i2c_eeprom`, `i3c_ccc`) in the command-line interface.

- Enhanced `README.md` with detailed descriptions of new examples and usage instructions.

- Updated `BridgeClient.cs`:
  - Fixed executable name from `"bridge"` to `"bmcbridge"`
  - Made `paramsDict` parameter nullable with proper null handling

- Added `Bridge_API_Reference.md` with complete API documentation:
  - Covers device management, I3C/I2C operations, and CCC commands
  - Includes troubleshooting guidance and best practices

## How to test

Run the examples